### PR TITLE
chore: made skip tests and javadoc of the root project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,4 +13,11 @@
     <module>lib</module>
     <module>yes</module>
   </modules>
+
+  <!-- Skip tests and javadoc of the root project -->
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
 </project>


### PR DESCRIPTION
This PR adds settings which suppress to create files or directories of tests or javadoc in the root directory to the root `pom.xml`