### PR TITLE
chore: changed predefined variables of project basedir

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -18,7 +18,7 @@
   <repositories>
     <repository>
       <id>local-m2-repository</id>
-      <url>file://${user.dir}/../local-m2-repository</url>
+      <url>file://${project.basedir}/../../local-m2-repository</url>
     </repository>
   </repositories>
 

--- a/yes/pom.xml
+++ b/yes/pom.xml
@@ -18,7 +18,7 @@
   <repositories>
     <repository>
       <id>local-m2-repository</id>
-      <url>file://${user.dir}/../local-m2-repository</url>
+      <url>file://${project.basedir}/../../local-m2-repository</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This PR changes `${user.dir}` to `${project.basedir}/..` in sub-projects' `pom.xml`.

`user.dir` does not indicates the base directory of the parent project but the working directory of the process that started the Java process when it started.